### PR TITLE
[23] Extend FIND_RECORDS to find by ID (#62)

### DIFF
--- a/src/api/api/BIOMD/BIOMD.js
+++ b/src/api/api/BIOMD/BIOMD.js
@@ -11,6 +11,7 @@
 //Required Libs
 // const { join } = require("path");
 // const media = require(join(CONFIG.Paths.HomeDir, CONFIG.Paths.API, "GLOBAL", "media"));
+const {ObjectId} = require('mongodb');
 const instituteCode = CONFIG.Database.Site_Database.Name;
 
 //Application Info
@@ -44,7 +45,7 @@ const MANUFACTURERS = "manufacturers";
 const EQUIPMENT_MODELS = "equipment_models";
 const VENDORS = "vendors";
 
-const OPERATORS = ["eq", "in", "gt", "lt", "sb"];
+const OPERATORS = ["eq", "in", "gt", "lt", "sb", "eq_id"];
 
 //Common Create Function
 const createOne = async function (doc, dbClient, collection) {
@@ -212,6 +213,9 @@ module.exports.FIND_RECORD = async function (req, dbClient) {
       let qry = queries[i]
       if (isValidOperator(qry.op)) {
         switch (qry.op) {
+          case "eq_id":
+            createdFindQuery["_id"] = ObjectId(qry.value);
+            break;
           case "eq":
             createdFindQuery[qry.field] = qry.value;
             break;


### PR DESCRIPTION
## Description
Changes Made:
- Add docs on BIOMD API interface
- Add eq_id operation in FIND call where the Value will be encapsulated in the Mongo ObjectId

## Related Issue
#23 

<!-- END_COMMIT_MESSAGE -->

## How Has This Been Tested?
Using API Testing Tool
1. Create a Manufacturer using API tool
2. Use the following FIND query with eq_id to get the manufacturer created in step 1 using the ID:
```json
{
  "Expiry": "20000",
  "Type": "REQUEST",
  "Request": {
    "Module": "MEMS",
    "ServiceCode": "BIOMD",
    "API": "FIND_RECORD",
    "return_array": true,
    "max_list": 5,
    "find": {
      "collection": "Manufacturer",
      "queries": [
        {
          "op": "eq_id",
          "value": "62ae5565ee3033c4977ea00d"
        }
      ],
      "projection": {
        "_id": 1,
        "manufacturer_name": 1
      }
    }
  }
}
```
