### PR TITLE
[92] FIND_RECORD: Allow filter for oID Fields

### DIFF
--- a/src/api/api/BIOMD/BIOMD.js
+++ b/src/api/api/BIOMD/BIOMD.js
@@ -207,7 +207,7 @@ module.exports.FIND_RECORD = async function (req, dbClient) {
       if (isValidOperator(qry.op)) {
         switch (qry.op) {
           case "eq_id":
-            createdFindQuery["_id"] = ObjectId(qry.value);
+            createdFindQuery[qry.field] = ObjectId(qry.value);
             break;
           case "eq":
             createdFindQuery[qry.field] = qry.value;


### PR DESCRIPTION
## Description
Fix FIND_RECORD api to allow querying for fields that are of ObjectID type in addition to the "_id" field.

## Related Issue
#92 

## Motivation and Context
Bugfix to allow finding Model records based on ManufacturerID

## How Has This Been Tested?
Tested by @akshaypuli 

